### PR TITLE
chore: use proper branch name for galaxy-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,3 +57,4 @@ jobs:
         uses: robertdebock/galaxy-action@1.2.1
         with:
           galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}
+          git_branch: "main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           docker push quay.io/egi/${{ matrix.umd_version }}:${{ matrix.os }}
 
       # Publish role to ansible galaxy
-      - name: galaxy
+      - name: Publish role to Ansible Galaxy
         uses: robertdebock/galaxy-action@1.2.1
         with:
           galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}


### PR DESCRIPTION
I've updated the credentials at the organisation level, and I've made some tests locally, and I was able to push using the command shown in the debug logs.

If it's not working with those changes, it may be desirable to try without relying on the third party extension.

Fix #23 